### PR TITLE
Abreviación de StepContributor info para la clasificación de errores

### DIFF
--- a/kukumo/kukumo-api/src/main/java/iti/kukumo/api/extensions/Contributor.java
+++ b/kukumo/kukumo-api/src/main/java/iti/kukumo/api/extensions/Contributor.java
@@ -10,7 +10,6 @@
 package iti.kukumo.api.extensions;
 
 import iti.commons.jext.Extension;
-import org.apache.commons.lang3.StringUtils;
 
 
 /** Base interface for all Kukumo extensions */
@@ -19,12 +18,14 @@ public interface Contributor {
     default String info() {
         Extension extensionData = this.getClass().getAnnotation(Extension.class);
         if (extensionData != null) {
-            return String.format("%s:%s", extensionData.provider(), extensionData.name());
+            return String.format(
+                    "%s:%s:%s",
+                    extensionData.provider(),
+                    extensionData.name(),
+                    extensionData.version()
+            );
         } else {
-            String pack = StringUtils.substringBeforeLast(
-                    StringUtils.abbreviate(getClass().getPackageName(), "", 14), ".");
-            return String.format("%s:%s", pack,
-                    StringUtils.abbreviate(getClass().getSimpleName(),  "", 14));
+            return getClass().getCanonicalName();
         }
     }
 

--- a/kukumo/kukumo-api/src/main/java/iti/kukumo/api/extensions/StepContributor.java
+++ b/kukumo/kukumo-api/src/main/java/iti/kukumo/api/extensions/StepContributor.java
@@ -3,18 +3,47 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
-/**
- * @author Luis Iñesta Gelabert - linesta@iti.es | luiinge@gmail.com
- */
 package iti.kukumo.api.extensions;
 
 
+import iti.commons.jext.Extension;
 import iti.commons.jext.ExtensionPoint;
 import iti.commons.jext.LoadStrategy;
+import iti.kukumo.api.util.Pair;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
 
 
 @ExtensionPoint(loadStrategy = LoadStrategy.FRESH)
 public interface StepContributor extends Contributor {
+
+    /**
+     * Cut the string into blocks of words separated by the indicated tokens
+     * until the maximum number of characters allowed is reached.
+     *
+     * @param str        The origin string
+     * @param maxLength  The total maximum number of characters
+     * @param separators The word separator tokens
+     * @return The abbreviated string
+     */
+    private static String abbreviate(String str, int maxLength, String... separators) {
+        String tokens = String.join("", separators);
+        str = str.length() < maxLength + 1 ? str + "."
+                : StringUtils.abbreviate(str, " ", maxLength + 2).trim();
+        String aux = str.replaceAll(String.format("(?:.(?![%s]))+$", tokens), "");
+        return aux.isBlank()
+                ? str.length() < maxLength + 1 ? str : str.substring(0, maxLength)
+                : aux;
+    }
+
+    default String info() {
+        Pair<String, String> info = Optional.ofNullable(this.getClass().getAnnotation(Extension.class))
+                .map(ext -> new Pair<>(ext.provider(), ext.name()))
+                .orElseGet(() -> new Pair<>(getClass().getPackageName(), getClass().getSimpleName()))
+                .mapEach(str -> abbreviate(str.toString(), 14, ".", "\\-", "_", "A-Z"));
+
+        return String.format("%s:%s", info.key(), info.value());
+    }
 
 }

--- a/kukumo/kukumo-api/src/main/java/iti/kukumo/api/util/Pair.java
+++ b/kukumo/kukumo-api/src/main/java/iti/kukumo/api/util/Pair.java
@@ -12,6 +12,7 @@ package iti.kukumo.api.util;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
@@ -38,6 +39,15 @@ public class Pair<T, U> {
         return value;
     }
 
+    public <R, P> Pair<R, P> map(BiFunction<T, U, Pair<R, P>> map) {
+        return map.apply(key, value);
+    }
+
+    public <R> Pair<R, R> mapEach(Function<Object, R> map) {
+        R key = map.apply(this.key);
+        R value = map.apply(this.value);
+        return new Pair<>(key, value);
+    }
 
     @Override
     public String toString() {

--- a/kukumo/kukumo-api/src/test/java/iti/kukumo/api/extensions/ContributorTest.java
+++ b/kukumo/kukumo-api/src/test/java/iti/kukumo/api/extensions/ContributorTest.java
@@ -1,0 +1,51 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package iti.kukumo.api.extensions;
+
+import iti.commons.jext.Extension;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ContributorTest {
+
+    @Test
+    public void testContributorInfo() {
+        assertThat(new TestContributor().info()).isEqualTo("iti.kukumo.api.extensions.ContributorTest.TestContributor");
+        assertThat(new TestContributorExt1().info()).isEqualTo("wakamiti-moreText:test-contrib-moreText:1.0");
+        assertThat(new TestContributorExt2().info()).isEqualTo("es.iti_somethingElse:test_somethingElse:1.0");
+        assertThat(new TestContributorExt3().info()).isEqualTo("es.iti_someText:test_aCapText:1.0");
+    }
+
+    @Test
+    public void testStepContributorInfo() {
+        assertThat(new TestStepContributor().info()).isEqualTo("iti.kukumo.api:TestStep");
+        assertThat(new TestStepContributorExt1().info()).isEqualTo("wakamiti-more:test-contrib");
+        assertThat(new TestStepContributorExt2().info()).isEqualTo("es.iti:test_something");
+        assertThat(new TestStepContributorExt3().info()).isEqualTo("es.iti_some:test_aCapText");
+        assertThat(new TestStepContributorExt4().info()).isEqualTo("thisisthenameo:nameoftheexten");
+    }
+
+
+    class TestContributor implements Contributor {}
+    @Extension(provider = "wakamiti-moreText", name = "test-contrib-moreText")
+    class TestContributorExt1 implements Contributor {}
+    @Extension(provider = "es.iti_somethingElse", name = "test_somethingElse")
+    class TestContributorExt2 implements Contributor { }
+    @Extension(provider = "es.iti_someText", name = "test_aCapText")
+    class TestContributorExt3 implements Contributor {}
+
+    class TestStepContributor implements StepContributor {}
+    @Extension(provider = "wakamiti-moreText", name = "test-contrib-moreText")
+    class TestStepContributorExt1 implements StepContributor {}
+    @Extension(provider = "es.iti_somethingElse", name = "test_somethingElse")
+    class TestStepContributorExt2 implements StepContributor {}
+    @Extension(provider = "es.iti_someText", name = "test_aCapText")
+    class TestStepContributorExt3 implements StepContributor {}
+    @Extension(provider = "thisisthenameofprovider", name = "nameoftheextension")
+    class TestStepContributorExt4 implements StepContributor {}
+
+}


### PR DESCRIPTION
Se modifica la obtención de la información de los step contributors para la clasificación de errores aplicando mecanismos de abreviación para que el string final no exceda de los 30 caracteres.
Se ha vuelto a dejar como estaba originalmente la obtención de la información de la interfaz de `Contributor`, porque sólo en los casos en los que se usa la interfaz `StepContributor` aplica que no se exceda de los 30 caracteres la información final.

**Nota**: Creo que lo ideal sería controlar la longitud de los campos `provider` y `name` de la anotación `Extension` al compilar para impedir que sean demasiado largos en lugar de tener que "cortarlo" durante la ejecución.