### PR TITLE
Expresiones Gpath en los evaluadores de json y xml

### DIFF
--- a/wakamiti/wakamiti-api/CHANGELOG.md
+++ b/wakamiti/wakamiti-api/CHANGELOG.md
@@ -1,0 +1,35 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][1],
+and this project adheres to [Semantic Versioning][2].
+
+## [Unreleased]
+
+### Added
+
+- Gpath expressions in json and xml evaluators
+
+
+## [1.5.1] - 2023-04-20
+
+### Added
+
+- Include error classifiers in result
+
+
+## [1.5.0] - 2023-01-17
+
+### Added
+
+- Property evaluators to read global properties and the results of previous steps [issue: #66]
+
+
+## [1.4.0] - 2022-05-09
+
+Initial release.  
+
+
+[1]: <https://keepachangelog.com/en/1.0.0/>
+[2]: <https://semver.org>

--- a/wakamiti/wakamiti-api/pom.xml
+++ b/wakamiti/wakamiti-api/pom.xml
@@ -69,10 +69,18 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-xml</artifactId>
+        </dependency>
         <!-- json -->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-json</artifactId>
         </dependency>
 
         <!-- test -->

--- a/wakamiti/wakamiti-api/src/main/java/es/iti/wakamiti/api/util/XmlUtils.java
+++ b/wakamiti/wakamiti-api/src/main/java/es/iti/wakamiti/api/util/XmlUtils.java
@@ -5,6 +5,8 @@
  */
 package es.iti.wakamiti.api.util;
 
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlRuntimeException;
@@ -103,9 +105,14 @@ public class XmlUtils {
                 }
             }
         } catch (XPathExpressionException e) {
-            throw new XmlRuntimeException(e);
+            Binding binding = new Binding();
+            binding.setVariable("obj", obj.toString());
+            binding.setVariable("exp", expression);
+            GroovyShell shell = new GroovyShell(binding);
+            return shell.evaluate("Eval.x(new groovy.xml.XmlSlurper().parseText(obj), 'x.' + exp)").toString();
         }
         return result.size() > 1 ? result.toString() : result.stream().findFirst().orElse("");
+
     }
 
 }

--- a/wakamiti/wakamiti-api/src/main/java/module-info.java
+++ b/wakamiti/wakamiti-api/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module es.iti.wakamiti.api {
     requires json.path;
     requires commons.beanutils;
     requires org.apache.commons.lang3;
+    requires org.codehaus.groovy;
 
     uses PropertyEvaluator;
     uses WakamitiAPI;

--- a/wakamiti/wakamiti-api/src/test/java/es/iti/wakamiti/api/util/JsonUtilsTest.java
+++ b/wakamiti/wakamiti-api/src/test/java/es/iti/wakamiti/api/util/JsonUtilsTest.java
@@ -8,6 +8,7 @@ package es.iti.wakamiti.api.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.jayway.jsonpath.PathNotFoundException;
 import com.jayway.jsonpath.PathNotFoundException;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -32,7 +33,9 @@ public class JsonUtilsTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     private final String json = "{\"name\":\"Arnold\",\"age\":47}";
-    private final String json_error = "{\"name:\"Arnold\",\"age\":47}";
+    private final String jsonError = "{\"name:\"Arnold\",\"age\":47}";
+
+    private final String jsonList = "{ \"list\": [{\"name\":\"Arnold\",\"age\":47},{\"name\":\"Susan\",\"age\":32}]}";
 
     @Test
     public void testJsonWhenStringWithSuccess() {
@@ -44,7 +47,7 @@ public class JsonUtilsTest {
 
     @Test(expected = RuntimeException.class)
     public void testJsonWhenStringWithError() {
-        JsonUtils.json(json_error);
+        JsonUtils.json(jsonError);
     }
 
     @Test
@@ -57,7 +60,7 @@ public class JsonUtilsTest {
 
     @Test(expected = RuntimeException.class)
     public void testJsonWhenStreamWithError() {
-        JsonUtils.json(new ByteArrayInputStream(json_error.getBytes()));
+        JsonUtils.json(new ByteArrayInputStream(jsonError.getBytes()));
     }
 
     @Test
@@ -123,6 +126,9 @@ public class JsonUtilsTest {
 
         result = JsonUtils.readStringValue(obj, "$..*.length()");
         assertThat(result).isEqualTo("6");
+
+        result = JsonUtils.readStringValue(JsonUtils.json(jsonList), "list.find{ it.name == 'Susan' }.age");
+        assertThat(result).isEqualTo("32");
     }
 
     @Test(expected = PathNotFoundException.class)

--- a/wakamiti/wakamiti-api/src/test/java/es/iti/wakamiti/api/util/XmlUtilsTest.java
+++ b/wakamiti/wakamiti-api/src/test/java/es/iti/wakamiti/api/util/XmlUtilsTest.java
@@ -31,7 +31,9 @@ import static org.mockito.Mockito.when;
 public class XmlUtilsTest {
 
     private final String xml = "<item><name>Arnold</name><age>47</age></item>";
-    private final String xml_error = "<item><nameArnold</name><age>47</age></item>";
+    private final String xmlError = "<item><nameArnold</name><age>47</age></item>";
+
+    private final String xmlList = "<list><item><name>Arnold</name><age>47</age></item><item><name>Susan</name><age>32</age></item></list>";
 
     @Test
     public void testXmlWhenStringWithSuccess() {
@@ -43,7 +45,7 @@ public class XmlUtilsTest {
 
     @Test(expected = XmlRuntimeException.class)
     public void testXmlWhenStringWithError() {
-        XmlUtils.xml(xml_error);
+        XmlUtils.xml(xmlError);
     }
 
     @Test
@@ -56,7 +58,7 @@ public class XmlUtilsTest {
 
     @Test(expected = XmlRuntimeException.class)
     public void testXmlWhenStreamWithError() {
-        XmlUtils.xml(new ByteArrayInputStream(xml_error.getBytes()));
+        XmlUtils.xml(new ByteArrayInputStream(xmlError.getBytes()));
     }
 
     @Test
@@ -144,18 +146,9 @@ public class XmlUtilsTest {
 
         result = XmlUtils.readStringValue(object, "//body/@id");
         assertThat(result).isEmpty();
+
+        result = XmlUtils.readStringValue(XmlUtils.xml(xmlList), "item.find{ it.name == 'Susan' }.age");
+        assertThat(result).isEqualTo("32");
     }
 
-    @Test(expected = XmlRuntimeException.class)
-    public void testReadStringValueWithError() throws XmlException, IOException {
-        XmlObject object = XmlUtils.xml("response",
-                Map.of(
-                        "statusCode", "200",
-                        "body", XmlObject.Factory.parse(new ByteArrayInputStream(xml.getBytes())),
-                        "headers", Map.of("keep-alive", "true", "content-type", "application/json"),
-                        "other", XmlObject.Factory.parse(new ByteArrayInputStream(xml.getBytes())).getDomNode()
-                ));
-
-        XmlUtils.readStringValue(object, "function(abc)");
-    }
 }

--- a/wakamiti/wakamiti-core/CHANGELOG.md
+++ b/wakamiti/wakamiti-core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
-## [1.7.0] -- 2023-05-03
+## [1.7.0] - 2023-05-03
 
 ### Added
 


### PR DESCRIPTION
Con esta funcionalidad se permite hacer más operaciones sobre json y xml. 
Por ejemplo, tenemos el siguiente json:
```json
{
  "list": [
    {"name": "Arnold", "age": 46},
    {"name": "Susan", "age": 32}
  ]
}
```
Podemos realizar expresiones como:
- `$.list.length` devuelve `2`
- `$.list[0].name` devuelve `Arnold`
- `list.find{ it.name == 'Susan' }.age` devuelve `32`