### PR TITLE
Hotfix/maven fetcher runtime dependencies

### DIFF
--- a/examples/spring-junit-example/pom.xml
+++ b/examples/spring-junit-example/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>es.iti.wakamiti</groupId>
             <artifactId>spring-wakamiti-plugin</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/spring-verify-example/pom.xml
+++ b/examples/spring-verify-example/pom.xml
@@ -151,7 +151,7 @@
                     <plugin>
                         <groupId>es.iti.wakamiti</groupId>
                         <artifactId>wakamiti-maven-plugin</artifactId>
-                        <version>2.6.0</version>
+                        <version>2.6.2</version>
                         <executions>
                             <!-- Executed at integration-test phase -->
                             <execution>

--- a/plugins/amqp-wakamiti-plugin/pom.xml
+++ b/plugins/amqp-wakamiti-plugin/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <qpid-broker.version>9.2.0</qpid-broker.version>
 
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/azure-wakamiti-plugin/pom.xml
+++ b/plugins/azure-wakamiti-plugin/pom.xml
@@ -25,7 +25,7 @@
     <inceptionYear>2023</inceptionYear>
 
     <properties>
-        <wakamiti-engine.version>2.6.0</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/cucumber-exporter-wakamiti-plugin/pom.xml
+++ b/plugins/cucumber-exporter-wakamiti-plugin/pom.xml
@@ -25,7 +25,7 @@
     <inceptionYear>2022</inceptionYear>
 
     <properties>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/db-wakamiti-plugin/pom.xml
+++ b/plugins/db-wakamiti-plugin/pom.xml
@@ -29,7 +29,7 @@
         <h2.version>2.2.224</h2.version>
         <test.containers>1.19.5</test.containers>
 
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/email-wakamiti-plugin/pom.xml
+++ b/plugins/email-wakamiti-plugin/pom.xml
@@ -24,7 +24,7 @@
     <inceptionYear>2023</inceptionYear>
 
     <properties>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/file-uploader-wakamiti-plugin/pom.xml
+++ b/plugins/file-uploader-wakamiti-plugin/pom.xml
@@ -16,7 +16,7 @@
     <name>[Wakamiti Plugin] File Uploader</name>
 
     <properties>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/groovy-wakamiti-plugin/pom.xml
+++ b/plugins/groovy-wakamiti-plugin/pom.xml
@@ -24,7 +24,7 @@
     <inceptionYear>2022</inceptionYear>
 
     <properties>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/html-report-wakamiti-plugin/pom.xml
+++ b/plugins/html-report-wakamiti-plugin/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <xmlunit.version>2.9.1</xmlunit.version>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <!-- dependencies -->

--- a/plugins/io-wakamiti-plugin/pom.xml
+++ b/plugins/io-wakamiti-plugin/pom.xml
@@ -25,7 +25,7 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
     <dependencies>

--- a/plugins/jmeter-wakamiti-plugin/pom.xml
+++ b/plugins/jmeter-wakamiti-plugin/pom.xml
@@ -29,7 +29,7 @@
         <mockserver.version>5.15.0</mockserver.version>
         <jackson.version>2.15.2</jackson.version>
 
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
 
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>us.abstracta.jmeter</groupId>
             <artifactId>jmeter-java-dsl</artifactId>
-            <version>1.25.3</version>
+            <version>1.29</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.groovy</groupId>

--- a/plugins/rest-wakamiti-plugin/pom.xml
+++ b/plugins/rest-wakamiti-plugin/pom.xml
@@ -30,7 +30,7 @@
         <rest-assured.version>5.4.0</rest-assured.version>
         <jackson.version>2.15.2</jackson.version>
 
-        <wakamiti-engine.version>2.6.1</wakamiti-engine.version>
+        <wakamiti-engine.version>2.6.2</wakamiti-engine.version>
     </properties>
 
 

--- a/plugins/spring-wakamiti-plugin/pom.xml
+++ b/plugins/spring-wakamiti-plugin/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>es.iti.wakamiti</groupId>
             <artifactId>wakamiti-core</artifactId>
-            <version>2.6.1</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>es.iti.wakamiti</groupId>

--- a/wakamiti-engine/CHANGELOG.md
+++ b/wakamiti-engine/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.6.2] - 2024-09-12
+
+### Fixed
+- Missing dependencies with `runtime` scope in `maven-fetcher`.
+
+
 ## [2.6.1] - 2024-09-12
 
 ### Fixed

--- a/wakamiti-engine/wakamiti-core/src/main/java/es/iti/wakamiti/core/WakamitiFetcher.java
+++ b/wakamiti-engine/wakamiti-core/src/main/java/es/iti/wakamiti/core/WakamitiFetcher.java
@@ -102,7 +102,7 @@ public class WakamitiFetcher {
             mavenFetcher.logger(logger);
 
             MavenFetchRequest fetchRequest = new MavenFetchRequest(modules)
-                    .scopes("compile", "provided");
+                    .scopes("compile", "runtime");
             MavenFetchResult fetchedArtifacts = mavenFetcher.fetchArtifacts(fetchRequest);
 
             if (logger.isDebugEnabled()) {


### PR DESCRIPTION
# [wakamiti-engine]

### Fixed
- Missing dependencies with `runtime` scope in `maven-fetcher`.