### PR TITLE
Fix incremental count

### DIFF
--- a/plugins/db-wakamiti-plugin/CHANGELOG.md
+++ b/plugins/db-wakamiti-plugin/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
 
+## [3.4.2] - 2024-12-17
+
+### Fixed
+- Each time it is checked in an asynchronous step, the number of records is set rather than incremented. (#335)
+
+
 ## [3.4.1] - 2024-12-13
 
 ### Fixed

--- a/plugins/db-wakamiti-plugin/pom.xml
+++ b/plugins/db-wakamiti-plugin/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>db-wakamiti-plugin</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
 
     <name>[Wakamiti Plugin] Database Steps</name>
     <description>Database steps for Wakamiti</description>

--- a/plugins/db-wakamiti-plugin/src/main/java/es/iti/wakamiti/database/DatabaseStepContributor.java
+++ b/plugins/db-wakamiti-plugin/src/main/java/es/iti/wakamiti/database/DatabaseStepContributor.java
@@ -1616,8 +1616,8 @@ public class DatabaseStepContributor extends DatabaseSupport implements StepCont
             args = {"table:word", "matcher:long-assertion", "duration:duration"})
     public void assertRowCountByClauseAsync(String table, Assertion<Long> matcher, Duration duration, Document clause) {
         AtomicLong result = new AtomicLong(0);
-        assertAsync(() -> matcher.test(result.addAndGet(countBy(table, clause.getContent()))), duration, () ->
-                Assertions.fail(message(
+        assertAsync(() -> matcher.test(result.updateAndGet(x -> countBy(table, clause.getContent()))), duration,
+                () -> Assertions.fail(message(
                         ERROR_ASSERT_SOME_RECORD_EXPECTED,
                         GIVEN_WHERE_CLAUSE,
                         Database.from(connection()).table(table),


### PR DESCRIPTION
### Fixed
- Each time it is checked in an asynchronous step, the number of records is set rather than incremented. (#335)
