### PR TITLE
fix(azure): test run results pagination issue

### DIFF
--- a/plugins/azure-wakamiti-plugin/CHANGELOG.md
+++ b/plugins/azure-wakamiti-plugin/CHANGELOG.md
@@ -6,10 +6,17 @@ The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
 
+## [2.1.2] - 2025-02-26
+
+### Fixed
+- The endpoint `/{organization}/{project}/_apis/test/Runs/{runId}/results` 
+  only returns a maximum of 1000 records.
+
+
 ## [2.1.1] - 2025-02-24
 
 ### Fixed
-- Concurrency limit of 100 every 10,000 milliseconds
+- Concurrency limit of 100 every 10,000 milliseconds.
 
 
 ## [2.1.0] - 2024-12-11

--- a/plugins/azure-wakamiti-plugin/pom.xml
+++ b/plugins/azure-wakamiti-plugin/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>azure-wakamiti-plugin</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <name>[Wakamiti Plugin] Azure integration</name>
     <description>Azure plan test integration</description>

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/AzureSynchronizer.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/AzureSynchronizer.java
@@ -218,7 +218,7 @@ public class AzureSynchronizer implements EventObserver {
                         .collect(Collectors.toList()));
         api().createRun(run);
         LOGGER.debug("Test run #{} ready to sync", run.id());
-        testResults = api().getResults(run)
+        testResults = api().getResults(run, testCases.size())
                 .peek(r -> r.testCase(findTestCase.apply(r.testCase().id())))
                 .collect(Collectors.toList());
         LOGGER.debug("{} remote test results ready to sync", testResults.size());


### PR DESCRIPTION

### Fixed

- The endpoint `/{organization}/{project}/_apis/test/Runs/{runId}/results` 
  only returns a maximum of 1000 records