### PR TITLE
Breaking change in `azure-wakamiti-plugin`

### DIFF
--- a/plugins/azure-wakamiti-plugin/CHANGELOG.md
+++ b/plugins/azure-wakamiti-plugin/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
 
+## [unreleased]
+
+### Changed
+- The identifier is now incorporated into the name of the test case, in the 
+  format `[ID-XX] Scenario Name`.
+
+
 ## [2.1.2] - 2025-02-26
 
 ### Fixed

--- a/plugins/azure-wakamiti-plugin/pom.xml
+++ b/plugins/azure-wakamiti-plugin/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>azure-wakamiti-plugin</artifactId>
-    <version>2.1.2</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>[Wakamiti Plugin] Azure integration</name>
     <description>Azure plan test integration</description>

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/AzureSynchronizer.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/AzureSynchronizer.java
@@ -229,12 +229,12 @@ public class AzureSynchronizer implements EventObserver {
             return;
         }
         Function<String, TestResult> findResult = t -> testResults.stream()
-                .filter(e -> e.testCase().tag().equals(t)).findFirst()
+                .filter(e -> e.testCase().identifier().equals(t)).findFirst()
                 .orElseThrow(() -> new WakamitiAzureException("No such test result '{}'", t));
         testResults = Mapper.ofType(testCasePerFeature ? GHERKIN_TYPE_FEATURE : GHERKIN_TYPE_SCENARIO)
                 .instance(suiteBase)
                 .mapResults(plan)
-                .map(r -> findResult.apply(r.testCase().tag()).merge(r))
+                .map(r -> findResult.apply(r.testCase().identifier()).merge(r))
                 .collect(Collectors.toList());
 
         api().updateResults(run, testResults);

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/AzureApi.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/AzureApi.java
@@ -53,6 +53,8 @@ public class AzureApi extends BaseApi<AzureApi> {
     private static final int MAX_LIST = 200;
     private static final int MAX_RESULTS = 1000;
 
+    private static final String JSON_PATCH = "application/json-patch+json";
+
     private final String configuration;
     private transient Function<String, String> tagExtractor;
     private Settings settings;
@@ -69,6 +71,10 @@ public class AzureApi extends BaseApi<AzureApi> {
         super(baseUrl);
         this.tagExtractor = tagExtractor;
         this.configuration = configuration;
+    }
+
+    private WorkItemOp workItemOp(WorkItemOp.Operation op, String field, String value) {
+        return new WorkItemOp().op(op).path(format("/fields/{}", field)).value(value);
     }
 
     /**
@@ -177,11 +183,21 @@ public class AzureApi extends BaseApi<AzureApi> {
      * @throws NoSuchElementException If the response body is empty.
      */
     private TestPlan createTestPlan(TestPlan plan) {
-        return newRequest()
+        TestPlan newPlan = newRequest()
                 .body(json(plan).toString())
                 .post(projectBase() + "/testplan/plans")
                 .body().map(json -> read(json, TestPlan.class))
                 .orElseThrow(() -> new NoSuchElementException("Empty body"));
+        List<WorkItemOp> ops = new ArrayList<>();
+        ops.add(workItemOp(WorkItemOp.Operation.ADD, TAGS, "wakamiti"));
+        newRequest()
+                .pathParam("id", newPlan.id())
+                .contentType(JSON_PATCH)
+                .body(json(ops).toString())
+                .patch(projectBase() + "/wit/workitems/{id}")
+                .body()
+                .orElseThrow(() -> new WakamitiException("Cannot tag test plan."));
+        return newPlan;
     }
 
     /**
@@ -387,16 +403,14 @@ public class AzureApi extends BaseApi<AzureApi> {
      * @return the created test cases, populated with IDs and other metadata.
      */
     public List<TestCase> createTestCases(TestPlan plan, List<TestCase> testCases) {
-        BiFunction<String, String, WorkItemOp> newWorkItem = (field, value) -> new WorkItemOp()
-                .op(WorkItemOp.Operation.ADD).path(format("/fields/{}", field)).value(value);
-
         testCases.stream().peek(t -> {
                     List<WorkItemOp> ops = new ArrayList<>();
-                    ops.add(newWorkItem.apply(TITLE, t.name()));
-                    ops.add(newWorkItem.apply(TAGS, t.tag()));
-                    ops.add(newWorkItem.apply(AREA_PATH, path(plan.area())));
-                    ops.add(newWorkItem.apply(ITERATION_PATH, path(plan.iteration())));
-                    Optional.ofNullable(t.description()).ifPresent(d -> ops.add(newWorkItem.apply(DESCRIPTION, d)));
+                    ops.add(workItemOp(WorkItemOp.Operation.ADD, TITLE, t.name()));
+                    ops.add(workItemOp(WorkItemOp.Operation.ADD, TAGS, t.tag()));
+                    ops.add(workItemOp(WorkItemOp.Operation.ADD, AREA_PATH, path(plan.area())));
+                    ops.add(workItemOp(WorkItemOp.Operation.ADD, ITERATION_PATH, path(plan.iteration())));
+                    Optional.ofNullable(t.description())
+                            .ifPresent(d -> ops.add(workItemOp(WorkItemOp.Operation.ADD, DESCRIPTION, d)));
                     newRequest()
                             .postCall(response -> response.body()
                                     .filter(x -> response.statusCode() < 400)
@@ -406,7 +420,7 @@ public class AzureApi extends BaseApi<AzureApi> {
                             .queryParam("$expand", "none")
                             .queryParam("suppressNotifications", false)
                             .queryParam("validateOnly", false)
-                            .header("Content-Type", "application/json-patch+json")
+                            .contentType(JSON_PATCH)
                             .body(json(ops).toString())
                             .post(projectBase() + "/wit/workitems/${type}")
                             .body().map(json -> readStringValue(json, "id"))
@@ -451,9 +465,6 @@ public class AzureApi extends BaseApi<AzureApi> {
      * @return the updated test cases.
      */
     public List<TestCase> updateTestCases(TestPlan plan, List<Pair<TestCase, TestCase>> testCases) {
-        BiFunction<String, String, WorkItemOp> newWorkItem = (field, value) -> new WorkItemOp()
-                .op(WorkItemOp.Operation.REPLACE).path(format("/fields/{}", field)).value(value);
-
         List<TestCase> remove = new LinkedList<>();
         List<TestCase> add = new LinkedList<>();
 
@@ -464,15 +475,15 @@ public class AzureApi extends BaseApi<AzureApi> {
                     TestCase oldT = p.key();
                     TestCase newT = p.value();
                     if (!oldT.name().equals(newT.name())) {
-                        ops.add(newWorkItem.apply(TITLE, newT.name()));
+                        ops.add(workItemOp(WorkItemOp.Operation.REPLACE, TITLE, newT.name()));
                     }
                     if (!Objects.equals(oldT.description(), newT.description())) {
-                        ops.add(newWorkItem.apply(DESCRIPTION, newT.description()));
+                        ops.add(workItemOp(WorkItemOp.Operation.REPLACE, DESCRIPTION, newT.description()));
                     }
                     newRequest()
                             .pathParam("id", oldT.id())
                             .body(json(ops).toString())
-                            .header("Content-Type", "application/json-patch+json")
+                            .contentType(JSON_PATCH)
                             .patch(projectBase() + "/wit/workitems/{id}");
                 });
 

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/AzureApi.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/AzureApi.java
@@ -27,9 +27,7 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
+import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -358,8 +356,10 @@ public class AzureApi extends BaseApi<AzureApi> {
                 .collect(Collectors.toList());
         List<Pair<TestCase, TestCase>> modSuiteTests = remoteTests.stream()
                 .filter(t -> tests.stream()
-                        .anyMatch(c -> t.tag().equals(c.tag()) && (t.isDifferent(c) || !t.suite().equals(c.suite()))))
-                .map(t -> new Pair<>(t, tests.stream().filter(x -> x.tag().equals(t.tag()))
+                        .anyMatch(c -> t.identifier().equals(c.identifier())
+                                && (t.isDifferent(c) || !t.suite().equals(c.suite()))))
+                .map(t -> new Pair<>(t, tests.stream()
+                        .filter(x -> x.identifier().equals(t.identifier()))
                         .map(x -> x.id(t.id())).findFirst().orElseThrow()))
                 .collect(Collectors.toList());
 
@@ -400,7 +400,8 @@ public class AzureApi extends BaseApi<AzureApi> {
                     newRequest()
                             .postCall(response -> response.body()
                                     .filter(x -> response.statusCode() < 400)
-                                    .orElseThrow(() -> new WakamitiAzureException("Cannot create test case '{}'. ", t.tag())))
+                                    .orElseThrow(() -> new WakamitiAzureException("Cannot create test case '{}'. ",
+                                            t.identifier())))
                             .pathParam("type", settings().testCaseType())
                             .queryParam("$expand", "none")
                             .queryParam("suppressNotifications", false)

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/BaseApi.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/BaseApi.java
@@ -106,6 +106,10 @@ public abstract class BaseApi<SELF extends HttpClient<SELF>> extends HttpClient<
         return String.format("/{%s}/{%s}/_apis", ORGANIZATION, PROJECT);
     }
 
+    protected SELF contentType(String contentType) {
+        return header("Content-Type", contentType);
+    }
+
     /**
      * Retrieves all pages of results from a paginated API endpoint.
      *

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/model/TestCase.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/model/TestCase.java
@@ -106,6 +106,10 @@ public class TestCase extends BaseModel {
         return new Object[]{tag};
     }
 
+    public String identifier() {
+        return this.name.replaceAll("^\\[([^]]+)].+$", "$1");
+    }
+
     public boolean isDifferent(TestCase testCase) {
         return Objects.nonNull(testCase) &&
                 (!this.name.equals(testCase.name) || !Objects.equals(this.description, testCase.description)

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/internal/Mapper.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/internal/Mapper.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static es.iti.wakamiti.api.util.StringUtils.format;
 import static es.iti.wakamiti.azure.AzureSynchronizer.GHERKIN_TYPE_FEATURE;
 import static es.iti.wakamiti.azure.AzureSynchronizer.GHERKIN_TYPE_SCENARIO;
 import static java.util.stream.Collectors.*;
@@ -100,20 +101,19 @@ public abstract class Mapper {
     /**
      * Maps a single plan node snapshot to a test case.
      *
-     * @param i      the order of the test case within its suite.
+     * @param idx      the order of the test case within its suite.
      * @param suite  the test suite to which the test case belongs.
      * @param target the plan node snapshot to map.
      * @return a test case representing the mapped plan node snapshot.
      */
-    protected TestCase caseMap(int i, TestSuite suite, PlanNodeSnapshot target) {
+    protected TestCase caseMap(int idx, TestSuite suite, PlanNodeSnapshot target) {
+        String id = Optional.of(target.getId()).filter(i -> !i.startsWith("#"))
+                .orElseThrow(() -> new WakamitiException("Target {} needs the idTag", gherkinType(target)));
         return new TestCase()
-                .name(target.getName())
+                .name(format("[{}] {}", id, target.getName()))
                 .description(join(target.getDescription(), System.lineSeparator()))
-                .tag(
-                        Optional.of(target.getId()).filter(id -> !id.startsWith("#"))
-                                .orElseThrow(() -> new WakamitiException("Target {} needs the idTag", gherkinType(target)))
-                )
-                .order(i)
+                .tag("wakamiti")
+                .order(idx)
                 .suite(suite.hasChildren(true))
                 .metadata(target);
     }

--- a/plugins/azure-wakamiti-plugin/src/main/java/module-info.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/module-info.java
@@ -12,4 +12,6 @@ module es.iti.wakamiti.azure {
     requires org.apache.commons.text;
     requires org.apache.commons.collections4;
 
+    opens es.iti.wakamiti.azure.api.model to com.fasterxml.jackson.databind;
+
 }

--- a/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/api/TestPlanApiTest.java
+++ b/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/api/TestPlanApiTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static es.iti.wakamiti.api.util.MapUtils.map;
 import static es.iti.wakamiti.api.util.StringUtils.format;
@@ -754,9 +755,9 @@ public class TestPlanApiTest {
         List<TestSuite> suites = List.of(root, new TestSuite().id("56985").name("Feature 1").parent(root));
 
         List<TestCase> testCases = List.of(
-                new TestCase().name("Scenario A").suite(suites.get(1)).order(0).tag("ID-1"),
-                new TestCase().name("Scenario B").suite(suites.get(1)).order(1).tag("ID-2"),
-                new TestCase().name("Scenario C").suite(suites.get(1)).order(2).tag("ID-3")
+                new TestCase().name("[ID-1] Scenario A").suite(suites.get(1)).order(0).tag("wakamiti"),
+                new TestCase().name("[ID-2] Scenario B").suite(suites.get(1)).order(1).tag("wakamiti"),
+                new TestCase().name("[ID-3] Scenario C").suite(suites.get(1)).order(2).tag("wakamiti")
         );
 
         // act
@@ -768,13 +769,13 @@ public class TestPlanApiTest {
         assertThat(remoteTestCases).hasSize(3);
         assertThat(remoteTestCases.get(0))
                 .hasFieldOrPropertyWithValue("id", "56977")
-                .hasFieldOrPropertyWithValue("name", "Scenario A");
+                .hasFieldOrPropertyWithValue("name", "[ID-1] Scenario A");
         assertThat(remoteTestCases.get(1))
                 .hasFieldOrPropertyWithValue("id", "56978")
-                .hasFieldOrPropertyWithValue("name", "Scenario B");
+                .hasFieldOrPropertyWithValue("name", "[ID-2] Scenario B");
         assertThat(remoteTestCases.get(2))
                 .hasFieldOrPropertyWithValue("id", "56979")
-                .hasFieldOrPropertyWithValue("name", "Scenario C");
+                .hasFieldOrPropertyWithValue("name", "[ID-3] Scenario C");
         remoteTestCases.forEach(t -> {
             assertThat(t.pointAssignments()).hasSize(1);
             assertThat(t.pointAssignments().get(0))
@@ -824,12 +825,12 @@ public class TestPlanApiTest {
                 new TestSuite().id("56986").name("Feature 2").parent(root)
         );
         List<TestCase> testCases = List.of(
-                new TestCase().name("Scenario A").suite(suites.get(1)).order(0).tag("ID-1"),
-                new TestCase().name("Scenario B").suite(suites.get(1)).order(1).tag("ID-2"),
-                new TestCase().name("Scenario C").suite(suites.get(1)).order(2).tag("ID-3"),
-                new TestCase().name("Scenario X").suite(suites.get(2)).order(0).tag("ID-1A"),
-                new TestCase().name("Scenario Y").suite(suites.get(2)).order(1).tag("ID-2A"),
-                new TestCase().name("Scenario Z").suite(suites.get(2)).order(2).tag("ID-3A")
+                new TestCase().name("[ID-1] Scenario A").suite(suites.get(1)).order(0).tag("wakamiti"),
+                new TestCase().name("[ID-2] Scenario B").suite(suites.get(1)).order(1).tag("wakamiti"),
+                new TestCase().name("[ID-3] Scenario C").suite(suites.get(1)).order(2).tag("wakamiti"),
+                new TestCase().name("[ID-1A] Scenario X").suite(suites.get(2)).order(0).tag("wakamiti"),
+                new TestCase().name("[ID-2A] Scenario Y").suite(suites.get(2)).order(1).tag("wakamiti"),
+                new TestCase().name("[ID-3A] Scenario Z").suite(suites.get(2)).order(2).tag("wakamiti")
         );
 
         for (TestCase t : testCases) {
@@ -843,11 +844,11 @@ public class TestPlanApiTest {
                                             "\\{\"op\":\"add\",\"path\":\"/fields/System\\.Tags\",\"value\":\"{}\"}.+" +
                                             "\\{\"op\":\"add\",\"path\":\"/fields/System\\.AreaPath\",\"value\":\"ACS\"}.+" +
                                             "\\{\"op\":\"add\",\"path\":\"/fields/System\\.IterationPath\",\"value\":\"ACS\\\\\\\\Iteración 1\"}.+",
-                                    t.name(), t.tag()))),
+                                    Pattern.quote(t.name()), t.tag()))),
                     response()
                             .withStatusCode(200)
                             .withContentType(MediaType.APPLICATION_JSON)
-                            .withBody(resource(format("server/workitems/post_{}.json", t.tag())))
+                            .withBody(resource(format("server/workitems/post_{}.json", t.identifier())))
             ).ifPresent(requests::add);
         }
 
@@ -884,28 +885,28 @@ public class TestPlanApiTest {
         assertThat(remoteTestCases).hasSize(6);
         assertThat(remoteTestCases.get(0))
                 .hasFieldOrPropertyWithValue("id", "56977")
-                .hasFieldOrPropertyWithValue("name", "Scenario A")
-                .hasFieldOrPropertyWithValue("tag", "ID-1");
+                .hasFieldOrPropertyWithValue("name", "[ID-1] Scenario A")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         assertThat(remoteTestCases.get(1))
                 .hasFieldOrPropertyWithValue("id", "56978")
-                .hasFieldOrPropertyWithValue("name", "Scenario B")
-                .hasFieldOrPropertyWithValue("tag", "ID-2");
+                .hasFieldOrPropertyWithValue("name", "[ID-2] Scenario B")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         assertThat(remoteTestCases.get(2))
                 .hasFieldOrPropertyWithValue("id", "56979")
-                .hasFieldOrPropertyWithValue("name", "Scenario C")
-                .hasFieldOrPropertyWithValue("tag", "ID-3");
+                .hasFieldOrPropertyWithValue("name", "[ID-3] Scenario C")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         assertThat(remoteTestCases.get(3))
                 .hasFieldOrPropertyWithValue("id", "56980")
-                .hasFieldOrPropertyWithValue("name", "Scenario X")
-                .hasFieldOrPropertyWithValue("tag", "ID-1A");
+                .hasFieldOrPropertyWithValue("name", "[ID-1A] Scenario X")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         assertThat(remoteTestCases.get(4))
                 .hasFieldOrPropertyWithValue("id", "56981")
-                .hasFieldOrPropertyWithValue("name", "Scenario Y")
-                .hasFieldOrPropertyWithValue("tag", "ID-2A");
+                .hasFieldOrPropertyWithValue("name", "[ID-2A] Scenario Y")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         assertThat(remoteTestCases.get(5))
                 .hasFieldOrPropertyWithValue("id", "56982")
-                .hasFieldOrPropertyWithValue("name", "Scenario Z")
-                .hasFieldOrPropertyWithValue("tag", "ID-3A");
+                .hasFieldOrPropertyWithValue("name", "[ID-3A] Scenario Z")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti");
         remoteTestCases.forEach(t -> {
             assertThat(t.pointAssignments()).hasSize(1);
             assertThat(t.pointAssignments().get(0))
@@ -949,10 +950,10 @@ public class TestPlanApiTest {
         List<TestSuite> suites = List.of(root, new TestSuite().id("56985").name("Feature 1").parent(root));
 
         List<TestCase> testCases = List.of(
-                new TestCase().name("Scenario A").suite(suites.get(1)).order(0).tag("ID-1"),
-                new TestCase().name("Scenario B").suite(suites.get(1)).order(1).tag("ID-2"),
-                new TestCase().name("Scenario C").suite(suites.get(1)).order(2).tag("ID-3"),
-                new TestCase().name("Scenario D").suite(suites.get(1)).order(3).tag("ID-4")
+                new TestCase().name("[ID-1] Scenario A").suite(suites.get(1)).order(0).tag("wakamiti"),
+                new TestCase().name("[ID-2] Scenario B").suite(suites.get(1)).order(1).tag("wakamiti"),
+                new TestCase().name("[ID-3] Scenario C").suite(suites.get(1)).order(2).tag("wakamiti"),
+                new TestCase().name("[ID-4] Scenario D").suite(suites.get(1)).order(3).tag("wakamiti")
         );
 
         // act
@@ -964,13 +965,13 @@ public class TestPlanApiTest {
         assertThat(remoteTestCases).hasSize(3);
         assertThat(remoteTestCases.get(0))
                 .hasFieldOrPropertyWithValue("id", "56977")
-                .hasFieldOrPropertyWithValue("name", "Scenario A");
+                .hasFieldOrPropertyWithValue("name", "[ID-1] Scenario A");
         assertThat(remoteTestCases.get(1))
                 .hasFieldOrPropertyWithValue("id", "56978")
-                .hasFieldOrPropertyWithValue("name", "Scenario B");
+                .hasFieldOrPropertyWithValue("name", "[ID-2] Scenario B");
         assertThat(remoteTestCases.get(2))
                 .hasFieldOrPropertyWithValue("id", "56979")
-                .hasFieldOrPropertyWithValue("name", "Scenario C");
+                .hasFieldOrPropertyWithValue("name", "[ID-3] Scenario C");
     }
 
     @Test
@@ -1000,12 +1001,12 @@ public class TestPlanApiTest {
                 new TestSuite().id("56986").name("Feature 2").parent(root)
         );
         List<Pair<String, TestCase>> testCases = List.of(
-                new Pair<>("56977", new TestCase().name("Scenario AA").suite(suites.get(2)).order(0).tag("ID-1")),
-                new Pair<>("56978", new TestCase().name("Scenario BB").suite(suites.get(2)).order(1).tag("ID-2")),
-                new Pair<>("56979", new TestCase().name("Scenario CC").suite(suites.get(2)).order(4).tag("ID-3")),
-                new Pair<>("56980", new TestCase().name("Scenario XX").suite(suites.get(1)).order(0).tag("ID-1A")),
-                new Pair<>("56981", new TestCase().name("Scenario YY").suite(suites.get(1)).order(1).tag("ID-2A")),
-                new Pair<>("56982", new TestCase().name("Scenario ZZ").suite(suites.get(1)).order(2).tag("ID-3A"))
+                new Pair<>("56977", new TestCase().name("[ID-1] Scenario AA").suite(suites.get(2)).order(0).tag("wakamiti")),
+                new Pair<>("56978", new TestCase().name("[ID-2] Scenario BB").suite(suites.get(2)).order(1).tag("wakamiti")),
+                new Pair<>("56979", new TestCase().name("[ID-3] Scenario CC").suite(suites.get(2)).order(4).tag("wakamiti")),
+                new Pair<>("56980", new TestCase().name("[ID-1A] Scenario XX").suite(suites.get(1)).order(0).tag("wakamiti")),
+                new Pair<>("56981", new TestCase().name("[ID-2A] Scenario YY").suite(suites.get(1)).order(1).tag("wakamiti")),
+                new Pair<>("56982", new TestCase().name("[ID-3A] Scenario ZZ").suite(suites.get(1)).order(2).tag("wakamiti"))
         );
 
         for (Pair<String, TestCase> p : testCases) {
@@ -1016,11 +1017,11 @@ public class TestPlanApiTest {
                             .withPath(format("/ST/ACS/_apis/wit/workitems/{}", p.key()))
                             .withBody(regex(format(".+" +
                                             "\\{\"op\":\"replace\",\"path\":\"/fields/System\\.Title\",\"value\":\"{}\"}.+",
-                                    p.value().name()))),
+                                    Pattern.quote(p.value().name())))),
                     response()
                             .withStatusCode(200)
                             .withContentType(MediaType.APPLICATION_JSON)
-                            .withBody(resource(format("server/workitems/patch_{}.json", p.value().tag())))
+                            .withBody(resource(format("server/workitems/patch_{}.json", p.value().identifier())))
             ).ifPresent(requests::add);
         }
 
@@ -1076,33 +1077,33 @@ public class TestPlanApiTest {
         assertThat(remoteTestCases).hasSize(6);
         assertThat(remoteTestCases.get(0))
                 .hasFieldOrPropertyWithValue("id", "56977")
-                .hasFieldOrPropertyWithValue("name", "Scenario AA")
-                .hasFieldOrPropertyWithValue("tag", "ID-1")
+                .hasFieldOrPropertyWithValue("name", "[ID-1] Scenario AA")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56986");
         assertThat(remoteTestCases.get(1))
                 .hasFieldOrPropertyWithValue("id", "56978")
-                .hasFieldOrPropertyWithValue("name", "Scenario BB")
-                .hasFieldOrPropertyWithValue("tag", "ID-2")
+                .hasFieldOrPropertyWithValue("name", "[ID-2] Scenario BB")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56986");
         assertThat(remoteTestCases.get(2))
                 .hasFieldOrPropertyWithValue("id", "56979")
-                .hasFieldOrPropertyWithValue("name", "Scenario CC")
-                .hasFieldOrPropertyWithValue("tag", "ID-3")
+                .hasFieldOrPropertyWithValue("name", "[ID-3] Scenario CC")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56986");
         assertThat(remoteTestCases.get(3))
                 .hasFieldOrPropertyWithValue("id", "56980")
-                .hasFieldOrPropertyWithValue("name", "Scenario XX")
-                .hasFieldOrPropertyWithValue("tag", "ID-1A")
+                .hasFieldOrPropertyWithValue("name", "[ID-1A] Scenario XX")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56985");
         assertThat(remoteTestCases.get(4))
                 .hasFieldOrPropertyWithValue("id", "56981")
-                .hasFieldOrPropertyWithValue("name", "Scenario YY")
-                .hasFieldOrPropertyWithValue("tag", "ID-2A")
+                .hasFieldOrPropertyWithValue("name", "[ID-2A] Scenario YY")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56985");
         assertThat(remoteTestCases.get(5))
                 .hasFieldOrPropertyWithValue("id", "56982")
-                .hasFieldOrPropertyWithValue("name", "Scenario ZZ")
-                .hasFieldOrPropertyWithValue("tag", "ID-3A")
+                .hasFieldOrPropertyWithValue("name", "[ID-3A] Scenario ZZ")
+                .hasFieldOrPropertyWithValue("tag", "wakamiti")
                 .extracting(t -> t.suite().id()).isEqualTo("56985");
     }
 

--- a/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/api/TestPlanApiTest.java
+++ b/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/api/TestPlanApiTest.java
@@ -521,6 +521,17 @@ public class TestPlanApiTest {
                         .withContentType(MediaType.APPLICATION_JSON)
                         .withBody(resource("server/plans/get/single.json"))
         ).ifPresent(requests::add);
+        mockServer(
+                request().withBody("PATCH").withPath("/ST/ACS/_apis/wit/workitems/56983")
+                        .withContentType(MediaType.APPLICATION_JSON_PATCH_JSON)
+                        .withBody(json("[" +
+                                "{\"op\":\"add\",\"path\":\"/fields/System.Tags\",\"value\":\"wakamiti\"}" +
+                                "]", MatchType.ONLY_MATCHING_FIELDS )),
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{}")
+        ).ifPresent(requests::add);
 
         AzureApi client = new AzureApi(new URL(BASE_URL), x -> x, null)
                 .organization("ST").projectBase("ACS").version("6.0-preview");

--- a/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/internal/MapperTest.java
+++ b/plugins/azure-wakamiti-plugin/src/test/java/es/iti/wakamiti/azure/internal/MapperTest.java
@@ -54,7 +54,7 @@ public class MapperTest {
                 .isNotEmpty()
                 .hasSize(1)
                 .allMatch(tc -> tc.suite().asPath().equals(Path.of("features/suite")))
-                .allMatch(tc -> tc.name().equals("Azure integration feature"));
+                .allMatch(tc -> tc.name().equals("[ID-azure-1] Azure integration feature"));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class MapperTest {
                 .isNotEmpty()
                 .hasSize(1)
                 .allMatch(tc -> tc.suite().asPath().equals(Path.of("suite")))
-                .allMatch(tc -> tc.name().equals("Azure integration feature"));
+                .allMatch(tc -> tc.name().equals("[ID-azure-1] Azure integration feature"));
     }
 
     @Test(expected = WakamitiException.class)
@@ -95,7 +95,7 @@ public class MapperTest {
                         && tc.suite().name().equals("azure")
                         && tc.suite().parent().name().equals("api/suite")
                 )
-                .allMatch(tc -> tc.name().equals("Azure integration feature"));
+                .allMatch(tc -> tc.name().equals("[ID-azure-1] Azure integration feature"));
     }
 
     @Test
@@ -109,11 +109,11 @@ public class MapperTest {
                 .isNotEmpty()
                 .hasSize(3)
                 .allMatch(tc -> tc.suite().asPath().equals(Path.of("features/suite/Azure integration feature")));
-        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario B");
+        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-1] Wakamiti Scenario B");
         assertThat(tests.get(0)).hasFieldOrPropertyWithValue("order", 0);
-        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario A");
+        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-2] Wakamiti Scenario A");
         assertThat(tests.get(1)).hasFieldOrPropertyWithValue("order", 1);
-        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario C");
+        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-3] Wakamiti Scenario C");
         assertThat(tests.get(2)).hasFieldOrPropertyWithValue("order", 2);
     }
 
@@ -128,11 +128,11 @@ public class MapperTest {
                 .isNotEmpty()
                 .hasSize(3)
                 .allMatch(tc -> tc.suite().asPath().equals(Path.of("suite/Azure integration feature")));
-        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario B");
+        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-1] Wakamiti Scenario B");
         assertThat(tests.get(0)).hasFieldOrPropertyWithValue("order", 0);
-        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario A");
+        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-2] Wakamiti Scenario A");
         assertThat(tests.get(1)).hasFieldOrPropertyWithValue("order", 1);
-        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario C");
+        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-3] Wakamiti Scenario C");
         assertThat(tests.get(2)).hasFieldOrPropertyWithValue("order", 2);
     }
 
@@ -160,11 +160,11 @@ public class MapperTest {
                         && tc.suite().name().equals("azure")
                         && tc.suite().parent().name().equals("api/suite")
                 );
-        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario B");
+        assertThat(tests.get(0)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-1] Wakamiti Scenario B");
         assertThat(tests.get(0)).hasFieldOrPropertyWithValue("order", 0);
-        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario A");
+        assertThat(tests.get(1)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-2] Wakamiti Scenario A");
         assertThat(tests.get(1)).hasFieldOrPropertyWithValue("order", 1);
-        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "Wakamiti Scenario C");
+        assertThat(tests.get(2)).hasFieldOrPropertyWithValue("name", "[ID-azure-1-3] Wakamiti Scenario C");
         assertThat(tests.get(2)).hasFieldOrPropertyWithValue("order", 2);
     }
 

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/list_56985.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/list_56985.json
@@ -2,13 +2,13 @@
   "value" : [ {
     "workItem" : {
       "id" : 56977,
-      "name" : "Scenario A",
+      "name" : "[ID-1] Scenario A",
       "workItemFields" : [ {
         "System.Id" : 56977
       }, {
-        "System.Title" : "Scenario A"
+        "System.Title" : "[ID-1] Scenario A"
       }, {
-        "System.Tags" : "ID-1"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "pointAssignments" : [ {
@@ -19,13 +19,13 @@
   }, {
     "workItem" : {
       "id" : 56978,
-      "name" : "Scenario B",
+      "name" : "[ID-2] Scenario B",
       "workItemFields" : [ {
         "System.Id" : 56978
       }, {
-        "System.Title" : "Scenario B"
+        "System.Title" : "[ID-2] Scenario B"
       }, {
-        "System.Tags" : "ID-2"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "order" : 1,
@@ -37,13 +37,13 @@
   }, {
     "workItem" : {
       "id" : 56979,
-      "name" : "Scenario C",
+      "name" : "[ID-3] Scenario C",
       "workItemFields" : [ {
         "System.Id" : 56979
       }, {
-        "System.Title" : "Scenario C"
+        "System.Title" : "[ID-3] Scenario C"
       }, {
-        "System.Tags" : "ID-3"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "order" : 2,

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/list_56986.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/list_56986.json
@@ -2,13 +2,13 @@
   "value" : [ {
     "workItem" : {
       "id" : 56980,
-      "name" : "Scenario X",
+      "name" : "[ID-1A] Scenario X",
       "workItemFields" : [ {
         "System.Id" : 56980
       }, {
-        "System.Title" : "Scenario X"
+        "System.Title" : "[ID-1A] Scenario X"
       }, {
-        "System.Tags" : "ID-1A"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "pointAssignments" : [ {
@@ -19,13 +19,13 @@
   }, {
     "workItem" : {
       "id" : 56981,
-      "name" : "Scenario Y",
+      "name" : "[ID-2A] Scenario Y",
       "workItemFields" : [ {
         "System.Id" : 56981
       }, {
-        "System.Title" : "Scenario Y"
+        "System.Title" : "[ID-2A] Scenario Y"
       }, {
-        "System.Tags" : "ID-2A"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "order" : 1,
@@ -37,13 +37,13 @@
   }, {
     "workItem" : {
       "id" : 56982,
-      "name" : "Scenario Z",
+      "name" : "[ID-3A] Scenario Z",
       "workItemFields" : [ {
         "System.Id" : 56982
       }, {
-        "System.Title" : "Scenario Z"
+        "System.Title" : "[ID-3A] Scenario Z"
       }, {
-        "System.Tags" : "ID-3A"
+        "System.Tags" : "wakamiti"
       } ]
     },
     "order" : 2,

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-1.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-1.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56977,
-      "name" : "Scenario A",
+      "name" : "[ID-1] Scenario A",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-1A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-1A.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56980,
-      "name" : "Scenario X",
+      "name" : "[ID-1A] Scenario X",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-2.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-2.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56978,
-      "name" : "Scenario B",
+      "name" : "[ID-2] Scenario B",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-2A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-2A.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56981,
-      "name" : "Scenario Y",
+      "name" : "[ID-2A] Scenario Y",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-3.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-3.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56979,
-      "name" : "Scenario C",
+      "name" : "[ID-3] Scenario C",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-3A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/testcases/post_ID-3A.json
@@ -11,7 +11,7 @@
     },
     "workItem" : {
       "id" : 56982,
-      "name" : "Scenario Z",
+      "name" : "[ID-3A] Scenario Z",
       "workItemFields" : [ {
         "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado"
       }, {

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-1.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-1.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario AA",
+    "System.Title" : "[ID-1] Scenario AA",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-1"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-1A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-1A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario XX",
+    "System.Title" : "[ID-1A] Scenario XX",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-1A"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-2.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-2.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario BB",
+    "System.Title" : "[ID-2] Scenario BB",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-2"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-2A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-2A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario YY",
+    "System.Title" : "[ID-2A] Scenario YY",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-2A"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-3.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-3.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario CC",
+    "System.Title" : "[ID-3] Scenario CC",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-3"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-3A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/patch_ID-3A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario ZZ",
+    "System.Title" : "[ID-3A] Scenario ZZ",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-3A"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-1.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-1.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario A",
+    "System.Title" : "[ID-1] Scenario A",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-1"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-1A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-1A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario X",
+    "System.Title" : "[ID-1A] Scenario X",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-1A"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-2.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-2.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario B",
+    "System.Title" : "[ID-2] Scenario B",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-2"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-2A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-2A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario Y",
+    "System.Title" : "[ID-2A] Scenario Y",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-2A"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-3.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-3.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario C",
+    "System.Title" : "[ID-3] Scenario C",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-3"
+    "System.Tags" : "wakamiti"
   }
 }

--- a/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-3A.json
+++ b/plugins/azure-wakamiti-plugin/src/test/resources/server/workitems/post_ID-3A.json
@@ -9,9 +9,9 @@
     "System.State" : "Diseño",
     "System.Reason" : "Nueva",
     "System.CommentCount" : 0,
-    "System.Title" : "Scenario Z",
+    "System.Title" : "[ID-3A] Scenario Z",
     "Microsoft.VSTS.Common.Priority" : 2,
     "Microsoft.VSTS.TCM.AutomationStatus" : "No automatizado",
-    "System.Tags" : "ID-3A"
+    "System.Tags" : "wakamiti"
   }
 }


### PR DESCRIPTION
### Changed
- The identifier is now incorporated into the name of the test case, in the 
  format `[ID-XX] Scenario Name`.

### Added
- The tag `wakamiti` is included in both test cases and test plans.
