### PR TITLE
New version azure-wakamiti-plugin-v3.0.2

### DIFF
--- a/plugins/azure-wakamiti-plugin/CHANGELOG.md
+++ b/plugins/azure-wakamiti-plugin/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
 
+## [3.0.2] - 2025-08-29
+
+### Fixed
+- Currently, when searching for a test case, it is expected to be associated 
+  with the same test suite as the one that is currently being executed.
+  However, this may not always be the case.
+- Issues related to modification of test cases.
+
+
 ## [3.0.1] - 2025-08-28
 
 ### Fixed

--- a/plugins/azure-wakamiti-plugin/pom.xml
+++ b/plugins/azure-wakamiti-plugin/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>azure-wakamiti-plugin</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
 
     <name>[Wakamiti Plugin] Azure integration</name>
     <description>Azure plan test integration</description>

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/model/TestCase.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/api/model/TestCase.java
@@ -103,7 +103,7 @@ public class TestCase extends BaseModel {
 
     @Override
     protected Object[] hashValues() {
-        return new Object[]{tag};
+        return new Object[]{identifier()};
     }
 
     public String identifier() {

--- a/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/internal/Mapper.java
+++ b/plugins/azure-wakamiti-plugin/src/main/java/es/iti/wakamiti/azure/internal/Mapper.java
@@ -111,7 +111,7 @@ public abstract class Mapper {
                 .orElseThrow(() -> new WakamitiException("Target {} needs the idTag", gherkinType(target)));
         return new TestCase()
                 .name(format("[{}] {}", id, target.getName()))
-                .description(join(target.getDescription(), System.lineSeparator()))
+//                .description(join(target.getDescription(), System.lineSeparator()))
                 .tag("wakamiti")
                 .order(idx)
                 .suite(suite.hasChildren(true))


### PR DESCRIPTION
### Fixed
- Currently, when searching for a test case, it is expected to be associated 
  with the same test suite as the one that is currently being executed.
  However, this may not always be the case.
- Issues related to modification of test cases.