### PR TITLE
New version rest-wakamiti-plugin-v2.9.4

### DIFF
--- a/plugins/rest-wakamiti-plugin/CHANGELOG.md
+++ b/plugins/rest-wakamiti-plugin/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
 
+## [2.9.4] - 2026-05-22
+
+### Fixed
+- Fixed `POST` requests failing when combining a request parameter and a body.
+  Request parameters are now sent as query parameters, so `POST` requests can
+  include both body payload and parameters at the same time.
+
+
 ## [2.9.3] - 2025-11-11
 
 ### Fixed

--- a/plugins/rest-wakamiti-plugin/pom.xml
+++ b/plugins/rest-wakamiti-plugin/pom.xml
@@ -18,7 +18,7 @@
 
 
     <artifactId>rest-wakamiti-plugin</artifactId>
-    <version>2.9.3</version>
+    <version>2.9.4</version>
 
     <name>[Wakamiti Plugin] REST Steps</name>
     <description>REST steps for Wakamiti</description>

--- a/plugins/rest-wakamiti-plugin/src/main/java/es/iti/wakamiti/rest/RestStepContributor.java
+++ b/plugins/rest-wakamiti-plugin/src/main/java/es/iti/wakamiti/rest/RestStepContributor.java
@@ -118,7 +118,7 @@ public class RestStepContributor extends RestSupport implements StepContributor 
      */
     @Step("rest.define.request.parameters")
     public void setRequestParameters(DataTable dataTable) {
-        specifications.add(request -> request.params(tableToMap(dataTable)));
+        specifications.add(request -> request.queryParams(tableToMap(dataTable)));
     }
 
     /**
@@ -129,7 +129,7 @@ public class RestStepContributor extends RestSupport implements StepContributor 
      */
     @Step(value = "rest.define.request.parameter", args = {"name:text", "value:text"})
     public void setRequestParameter(String name, String value) {
-        specifications.add(request -> request.param(name, value));
+        specifications.add(request -> request.queryParam(name, value));
     }
 
     /**

--- a/plugins/rest-wakamiti-plugin/src/test/java/es/iti/wakamiti/rest/RestStepContributorTest.java
+++ b/plugins/rest-wakamiti-plugin/src/test/java/es/iti/wakamiti/rest/RestStepContributorTest.java
@@ -1777,6 +1777,35 @@ public class RestStepContributorTest {
     }
 
     /**
+     * Test {@link RestStepContributor#setRequestParameter(String, String)} and
+     * {@link RestStepContributor#executePostSubjectUsingDocument(Document)}
+     */
+    @Test
+    public void testWhenPostSubjectDocumentAndParamWithSuccess() {
+        // prepare
+        mockServer(
+                request()
+                        .withMethod("POST")
+                        .withPath("/")
+                        .withQueryStringParameter("param1", "value1")
+                        .withBody(json(map("user", "Pepe")))
+                ,
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // act
+        contributor.setRequestParameter("param1", "value1");
+        JsonNode result = (JsonNode) contributor
+                .executePostSubjectUsingDocument(new Document(json(map("user", "Pepe"))));
+
+        // check
+        assertThat(result).isNotNull();
+        assertThat(JsonUtils.readStringValue(result, "statusCode")).isEqualTo("200");
+    }
+
+    /**
      * Test {@link RestStepContributor#executePatchSubjectUsingFile(File)}
      */
     @Test
@@ -1812,9 +1841,8 @@ public class RestStepContributorTest {
                 request()
                         .withMethod("POST")
                         .withPath("/")
-                        .withBody(
-                                params(param("param1", "value1"))
-                        )
+                        .withQueryStringParameter("param1", "value1")
+                        .withBody(Not.not(regex(".+")))
                 ,
                 response()
                         .withStatusCode(200)
@@ -1944,9 +1972,8 @@ public class RestStepContributorTest {
                 request()
                         .withMethod("POST")
                         .withPath("/")
-                        .withBody(
-                                params(param("param1", "value1"))
-                        )
+                        .withQueryStringParameter("param1", "value1")
+                        .withBody(Not.not(regex(".+")))
                 ,
                 response()
                         .withStatusCode(200)


### PR DESCRIPTION
### Fixed
- Fixed `POST` requests failing when combining a request parameter and a body.
  Request parameters are now sent as query parameters, so `POST` requests can
  include both body payload and parameters at the same time.